### PR TITLE
Inlined functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::{collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, Linked
 pub trait Len {
     fn len(&self) -> usize;
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -10,36 +11,42 @@ pub trait Len {
 
 // IMPLEMENTATIONS
 impl Len for str {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl Len for String {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T> Len for Vec<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T> Len for VecDeque<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T: ?Sized + Len> Len for Box<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.as_ref().len()
     }
 }
 
 impl<T> Len for [T] {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
@@ -53,6 +60,7 @@ impl<T, const N: usize> Len for [T;N] {
 
 #[cfg(feature = "pyo3")]
 impl Len for pyo3::PyAny {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len().expect("Failed to get length!")
     }
@@ -60,6 +68,7 @@ impl Len for pyo3::PyAny {
 
 #[cfg(feature = "pyo3")]
 impl Len for &pyo3::PyAny {
+    #[inline(always)]
     fn len(&self) -> usize {
         (*self).len().expect("Failed to get length!")
     }
@@ -67,6 +76,7 @@ impl Len for &pyo3::PyAny {
 
 #[cfg(feature = "pyo3")]
 impl Len for serde_json::Value {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.to_owned().len()
     }
@@ -74,48 +84,56 @@ impl Len for serde_json::Value {
 
 #[cfg(feature = "serde_crates")]
 impl Len for &serde_json::Value {
+    #[inline(always)]
     fn len(&self) -> usize {
         (*self).len()
     }
 }
 
 impl<K: Eq + Hash, V> Len for HashMap<K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<K: Eq + Hash> Len for HashSet<K> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T> Len for LinkedList<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl Len for CStr {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.as_ref().len()
     }
 }
 
 impl Len for CString {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.as_ref().len()
     }
 }
 
 impl Len for OsStr {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl Len for OsString {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.as_os_str().len()
     }
@@ -123,18 +141,21 @@ impl Len for OsString {
 
 
 impl<K: Ord, V> Len for BTreeMap<K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T: Ord> Len for BTreeSet<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T: Ord> Len for BinaryHeap<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ impl<T> Len for [T] {
 }
 
 impl<T, const N: usize> Len for [T;N] {
+    #[inline(always)]
     fn len(&self) -> usize {
         N
     }
@@ -114,7 +115,7 @@ impl<T> Len for LinkedList<T> {
 impl Len for CStr {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.as_ref().len()
+        self.to_bytes().len()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl<T> Len for [T] {
     }
 }
 
-impl<T, const N: usize> for [T;N] {
+impl<T, const N: usize> Len for [T;N] {
     fn len(&self) -> usize {
         N
     }


### PR DESCRIPTION
The compiler will probably automatically inline the functions as part of its optimization, but it's nice to explicitly declare it as inlined to ensure that that fraction of performance overhead from that extra function call doesn't occur.

Also I fixed a dumb error from my previous PR where I forgot the name of the trait in the impl block, and I fixed the CStr implementation.